### PR TITLE
Some improvements:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ cython_debug/
 
 # download folders
 downloads/*
+
+# CDN Hosts
+cdn_hosts.txt

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # Bunkrr Media Downloader
 
-This Python script allows users to download media files from bunkrr Albums.
-
-## Description
-
-The script fetches image data from a bunkrr Album URL provided by the user and proceeds to download the images into a specified folder.
+Downloads media from Bunkr albums, following click‑through pages and CDN redirects automatically.
 
 ## Features
 
-- **Multiple URL Support**: Download media from multiple bunkrr album URLs provided by the user.
-- **Asynchronous Download**: Downloads media asynchronously to improve efficiency.
-- **Folder Organization**: Saves downloaded media into separate folders for each album.
+- Multiple album URLs or a file with URLs
+- Asynchronous downloads with configurable concurrency
+- Album pagination discovery (fetches all pages)
+- Resolves Bunkr “Download” pages and follows to CDN
+- Uses album titles for filenames; sanitizes and dedupes
+- Skips files that already exist in the album folder
 
 ## Requirements
 
@@ -23,26 +22,21 @@ The script fetches image data from a bunkrr Album URL provided by the user and p
 
 ## Installation
 
-1. Clone the repository:
+1. Clone and enter the repo:
 
    ```bash
    git clone https://github.com/najahiiii/bonkrr.git
-   ```
-
-2. Navigate to the project directory:
-
-   ```bash
    cd bonkrr
    ```
 
-3. Create and activate a virtual environment:
+2. Create and activate a virtualenv:
 
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate
    ```
 
-4. Install the required packages inside the virtual environment:
+3. Install deps:
 
    ```bash
    pip install -r requirements.txt
@@ -50,14 +44,65 @@ The script fetches image data from a bunkrr Album URL provided by the user and p
 
 ## Usage
 
-1. Run the script:
+```bash
+python3 -m bunkrr
+```
 
-   ```bash
-   python3 -m bunkrr
-   ```
+Follow the prompts and paste one or more album URLs. A downloads folder is created with one subfolder per album.
 
-2. Enter the bunkrr Album URL and the download folder path as prompted.
-3. The script will begin fetching and downloading the media files. The progress will be displayed.
+## Environment Options
+
+- `BUNKR_CONCURRENCY`
+  - Integer; default `12`.
+  - Controls the number of parallel downloads. Lower when hitting rate limits (e.g., `3–6`).
+- `BUNKR_DEBUG`
+  - `1`/`true` to print resolver steps (album pages, each GET hop, CDN trials, save paths).
+- `BUNKR_LIMIT`
+  - Integer; process only the first N items (handy with debug).
+- `BUNKR_CDN_EXTRA`
+  - Comma/space‑separated list of additional CDN hosts to try for this run.
+  - Accepts either a subdomain prefix (`beer`) or a full hostname (`c1.cache8.st`).
+- `BUNKR_CDN_FILE`
+  - Path to a file listing extra CDN hosts, one per line (comments with `#` allowed).
+  - Defaults to `cdn_hosts.txt` in the current directory.
+  - Set to empty (`""`) to disable creating/updating the file.
+
+Notes:
+
+- The downloader auto‑discovers the file path from the album’s “get” page, then probes CDN hosts. The first working host in a session becomes the preferred host and is tried first next time. Discovered hosts are appended to `cdn_hosts.txt` unless disabled.
+- Existing files are skipped before downloads start (including deduped variants like `Name (1).mp4`).
+
+## Adding CDN Hosts
+
+You can supply new CDN hosts in three ways (highest priority first):
+
+1) Preferred (auto‑learned): once a host works (e.g., `rum.bunkr.ru`), it is tried first for the rest of the session and written to `cdn_hosts.txt`.
+
+2) Built‑in + extras: the downloader ships with a list of known hosts; add more for a single run via:
+  `BUNKR_CDN_EXTRA="maple nachos bacon" python3 -m bunkrr`
+
+3) Persistent file: maintain `cdn_hosts.txt` with one host per line (prefix like `beer` or full host like `c1.cache8.st`). Example:
+
+```text
+# extra bunkr subdomains
+maple
+rice
+
+# external CDNs
+mlk-bk.cdn.gigachad-cdn.ru
+c1.cache8.st
+```
+
+Disable persistence by running with `BUNKR_CDN_FILE=""`.
+
+## Troubleshooting
+
+- If many items fail to resolve, try lowering concurrency:
+  - `BUNKR_CONCURRENCY=4 python3 -m bunkrr`
+- If you see a new CDN host in your browser (e.g., `maple.bunkr.ru`), add it via:
+  - `BUNKR_CDN_EXTRA="maple" python3 -m bunkrr` or add `maple` to `cdn_hosts.txt`.
+- For diagnosis on a small slice:
+  - `BUNKR_DEBUG=1 BUNKR_LIMIT=5 python3 -m bunkrr`
 
 ## Contributors
 
@@ -65,4 +110,4 @@ The script fetches image data from a bunkrr Album URL provided by the user and p
 
 ## License
 
-This project is licensed under the [MIT License](https://github.com/najahiiii/bonkrr/blob/main/LICENSE).
+This project is licensed under the [MIT License](LICENSE).

--- a/bunkrr/data_processing.py
+++ b/bunkrr/data_processing.py
@@ -10,7 +10,29 @@ from tqdm import tqdm
 
 from bunkrr.utils import dedupe_path, get_filename
 
-MAX_CONCURRENT_DOWNLOADS = 16
+MAX_CONCURRENT_DOWNLOADS = int(os.environ.get("BUNKR_CONCURRENCY", "12") or 12)
+
+# Debug flag controlled by env var BUNKR_DEBUG
+DEBUG = os.environ.get("BUNKR_DEBUG", "").lower() in {"1", "true", "yes", "on"}
+LIMIT = 0
+try:
+    LIMIT = int(os.environ.get("BUNKR_LIMIT", "0") or 0)
+except ValueError:
+    LIMIT = 0
+
+
+def dbg(msg: str) -> None:
+    """
+    Print a debug message when the DEBUG flag is enabled.
+
+    Args:
+        msg (str): Message to print when debug logging is active.
+
+    Returns:
+        None
+    """
+    if DEBUG:
+        print(f"[debug] {msg}")
 
 
 def get_random_user_agent():

--- a/bunkrr/downloader.py
+++ b/bunkrr/downloader.py
@@ -7,12 +7,8 @@ from urllib.parse import urljoin
 
 from aiohttp import ClientSession
 
-from bunkrr.data_processing import (
-    create_download_folder,
-    download_images_from_urls,
-    fetch_data,
-)
-from bunkrr.utils import choices, get_user_folder, sanitize
+from bunkrr.data_processing import download_images_from_urls, fetch_data
+from bunkrr.utils import choices, create_download_folder, get_user_folder, sanitize
 
 
 async def fetch_album_data(

--- a/bunkrr/utils.py
+++ b/bunkrr/utils.py
@@ -8,6 +8,30 @@ from typing import Mapping, Optional
 
 DEFAULT_PARENT_FOLDER = "downloads"
 
+async def create_download_folder(base_path: str, *args: str) -> str:
+    """
+    Create a download folder at the specified base path (async-friendly wrapper).
+
+    Args:
+        base_path (str): Base path where the folder should be created.
+        *args (str): Optional subfolder components to nest under base_path.
+
+    Returns:
+        str: The path to the created (or existing) folder.
+    """
+    if len(args) == 1:
+        folder_name = args[0]
+        path = os.path.join(base_path, folder_name)
+        if not os.path.exists(path):
+            os.makedirs(path)
+    else:
+        folder_name = os.path.join(base_path, *args) if args else base_path
+        if not os.path.exists(folder_name):
+            os.makedirs(folder_name)
+        path = folder_name
+
+    return path
+
 
 def choices(prompt: str) -> Optional[None]:
     """


### PR DESCRIPTION
FAIR WARNING: 
> This code has been prepared with AI

I noticed there were problems with downloading some files off big albums and, whist trying to fix it I struggled with some problems. I turned to AI, and this code is a result of it. I understand if it won't be merged though.

Quick changes walk through:
1. Omit already downloaded files
2. Maintain a list of CDN URLs and make sure you can download all files
3. Add an env_var to limit concurrency of downloads
4. Fix duplication of album names in ./downloads
5. Add DEBUG option to help with bug fixing
6. Show list of files that were not downloaded before quitting

Bunkrr sometimes rate limits, so with big albums it might be required to run the program a few times to get all files.

In testing I downloaded 93 files album by running the code twice, and a whopping 807 item album with around 6 code runs.